### PR TITLE
fix: replace incorrect git clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To work on this project, ensure you have the following installed:
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/kec-computer-club/website.git
+git clone https://github.com/computerclubkec/computerclubkec.github.io.git
 ```
    
 2. Navigate to the project directory:


### PR DESCRIPTION
### Summary 
This PR fixes the incorrect Git clone URL in the README file. The previous URL pointed to the wrong repository.

### Reason for Change
The incorrect clone URL could lead users to the wrong repository, making it difficult to clone the project correctly.

This PR resolves issue #44
