### PR TITLE
fix: update incorrect git clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To work on this project, ensure you have the following installed:
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/kec-computer-club/website.git
+git clone https://github.com/computerclubkec/computerclubkec.github.io.git
 ```
    
 2. Navigate to the project directory:


### PR DESCRIPTION
This pull request fixes the incorrect Git clone URL in the README file. The URL has been updated from:
`git clone https://github.com/kec-computer-club/website.git`
to:
`git clone https://github.com/computerclubkec/computerclubkec.github.io.git`.

Fixes #44.
