### PR TITLE
feat: add Recent Events section

### DIFF
--- a/_events/2024-12-01-hack-a-lite.markdown
+++ b/_events/2024-12-01-hack-a-lite.markdown
@@ -13,7 +13,7 @@ location: "Kantipur Engineering College"
 registration_link: "#"
 participants: "150+ people registered"
 
-completed: false
+completed: true
 
 tags: ["hackathon", "innovation", "coding"]
 published: true

--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -1,0 +1,65 @@
+<div class="container py-10 px-2 md:mx-auto">
+  <h2
+    class="text-5xl font-bold text-[{{site.text-colors.darkblue}}] text-center mb-8"
+  >
+    Recent Events
+  </h2>
+
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
+    {% for event in site.events %} {% if event.completed %}
+    <div
+      class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg"
+    >
+      <div class="flex flex-col md:flex-row items-start md:items-center">
+        <!-- Event Image -->
+        <div class="md:w-1/3 w-full mb-4 md:mb-0">
+          <img
+            src="{{ event.banner_image }}"
+            alt="{{ event.title }}"
+            class="w-full h-auto rounded-lg"
+          />
+        </div>
+
+        <!-- Event Info -->
+        <div class="md:w-2/3 w-full md:pl-6">
+          <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
+          <p class="text-sm text-gray-400 italic font-semibold">
+            {{ event.date | date: "%a, %B %e, %Y" }}
+          </p>
+
+          <!-- Event Description with Show More/Show Less -->
+          <p class="text-sm my-2">
+            <!-- Shortened version of the description -->
+            <span class="event-description-short"
+              >{{ event.description | truncate: 120, "..." }}</span
+            >
+            <!-- Full description, hidden initially -->
+            <span class="event-description-full hidden"
+              >{{ event.description }}</span
+            >
+
+            <!-- Read More / Read Less buttons -->
+            <a href="#" class="text-blue-400 read-more">Read More</a>
+            <a href="#" class="text-blue-400 read-less hidden">Show Less</a>
+          </p>
+
+          <p class="text-sm mb-1 text-gray-400 font-bold">
+            {{ event.participants }}
+          </p>
+        </div>
+      </div>
+    </div>
+    {% endif %} {% endfor %}
+  </div>
+
+
+  <div class="flex justify-center mt-8">
+    <button
+      type="button"
+      class="text-[{{site.bg-colors.orange-button}}] hover:text-white border-2 border-[{{site.bg-colors.orange-button}}] hover:bg-[{{site.bg-colors.orange-button}}] focus:ring-4 focus:outline-none focus:ring-[{{site.bg-colors.orange-button}}]/50 font-medium rounded-lg text-xs sm:text-sm md:text-base lg:text-lg px-4 sm:px-6 py-2 sm:py-3 text-center mb-2 dark:border-[{{site.bg-colors.orange-button}}] dark:text-[{{site.bg-colors.orange-button}}] dark:hover:text-white dark:hover:bg-[{{site.bg-colors.orange-button}}] dark:focus:ring-[{{site.bg-colors.orange-button}}]/80"
+    >
+      See More
+    </button>
+  </div>
+  
+</div>

--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -54,12 +54,12 @@
 
 
   <div class="flex justify-center mt-8">
-    <button
-      type="button"
+    <a
+      href="/past-events"
       class="text-[{{site.bg-colors.orange-button}}] hover:text-white border-2 border-[{{site.bg-colors.orange-button}}] hover:bg-[{{site.bg-colors.orange-button}}] focus:ring-4 focus:outline-none focus:ring-[{{site.bg-colors.orange-button}}]/50 font-medium rounded-lg text-xs sm:text-sm md:text-base lg:text-lg px-4 sm:px-6 py-2 sm:py-3 text-center mb-2 dark:border-[{{site.bg-colors.orange-button}}] dark:text-[{{site.bg-colors.orange-button}}] dark:hover:text-white dark:hover:bg-[{{site.bg-colors.orange-button}}] dark:focus:ring-[{{site.bg-colors.orange-button}}]/80"
     >
       See More
-    </button>
+  </a>
   </div>
   
 </div>

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -6,7 +6,8 @@
   </h2>
 
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
-    {% for event in site.events %} {% unless event.completed %}
+    {% assign upcoming_events = site.events | where: 'completed', false | sort: 'date' | limit: 4 %}
+    {% for event in upcoming_events %}
     <div
       class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg"
     >
@@ -48,7 +49,6 @@
           </p>
 
           <!-- Register Button -->
-
           <a
             href="{{ event.url }}"
             class="inline-block bg-[{{site.bg-colors.orange-button}}] text-white font-semibold px-4 py-2 rounded-lg mt-2 hover:bg-[{{site.bg-colors.orange-button}}]/80"
@@ -58,6 +58,6 @@
         </div>
       </div>
     </div>
-    {% endunless %} {% endfor %}
+    {% endfor %}
   </div>
 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -83,10 +83,12 @@
     <!-- Metrics Banner Ends Here -->
 
     <!-- Upcoming Events section starts Here -->
-
     {% include upcoming-events.html %}
-
     <!-- Upcoming Events Section ends Here -->
+
+    <!-- Recent Events Section Starts Here -->
+     {% include recent-events.html %}
+     <!-- Recent Events Section Ends Here -->
 
     <!-- Brands collabration section starts here -->
     {% include brands_colab.html %}


### PR DESCRIPTION
This PR resolves #49 

## Changes

- Create a layout called `recent-events.html`. Here, events that are marked as completed will be shown.
- Sort the completed events according to the date and show the last 4 events only
- Create a see more button that redirects to `/past-events`

## Output

<img width="1703" alt="Screenshot 2024-10-07 at 3 26 50 AM" src="https://github.com/user-attachments/assets/ece5918a-d626-4522-8faf-32e3f9228214">
