### PR TITLE
feat: add event url and animation to event card

### DIFF
--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -7,8 +7,9 @@
 
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
     {% for event in site.events %} {% if event.completed %}
+    <a href="{{ event.url }}" class="block">
     <div
-      class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg"
+      class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
     >
       <div class="flex flex-col md:flex-row items-start md:items-center">
         <!-- Event Image -->
@@ -39,8 +40,8 @@
             >
 
             <!-- Read More / Read Less buttons -->
-            <a href="#" class="text-blue-400 read-more">Read More</a>
-            <a href="#" class="text-blue-400 read-less hidden">Show Less</a>
+            <button class="text-blue-400 read-more">Read More</button>
+            <button class="text-blue-400 read-less hidden">Show Less</button>
           </p>
 
           <p class="text-sm mb-1 text-gray-400 font-bold">
@@ -49,6 +50,7 @@
         </div>
       </div>
     </div>
+  </a>
     {% endif %} {% endfor %}
   </div>
 

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -31,15 +31,21 @@
             {{ event.date | date: "%a, %B %e, %Y" }}
           </p>
 
-          <!-- Event Description with Show More -->
+          <!-- Event Description with Show More/Show Less -->
           <p class="text-sm my-2">
             <!-- Shortened version of the description -->
             <span class="event-description-short"
               >{{ event.description | truncate: 120, "..." }}</span
             >
+            <!-- Full description, hidden initially -->
+            <span class="event-description-full hidden"
+              >{{ event.description }}</span
+            >
 
             <!-- Read More / Read Less buttons -->
-            <button class="text-blue-400 read-more">Read More</button>
+            <button class="text-blue-400 read-more relative z-10">Read More</button>
+            <button class="text-blue-400 read-less hidden relative z-10">Show Less</button>
+          </p>
 
           <p class="text-sm mb-1 text-gray-400 font-bold">
             {{ event.participants }}

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -8,11 +8,13 @@
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
     {% assign upcoming_events = site.events | where: 'completed', false | sort: 'date' | limit: 4 %}
     {% for event in upcoming_events %}
-    <a href="{{ event.url }}" class="block">
+    
     <div
-      class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
+      class="relative bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
     >
+      <a href="{{ event.url }}" class="absolute inset-0 block"></a>
       <div class="flex flex-col md:flex-row items-start md:items-center">
+        
         <!-- Event Image -->
         <div class="md:w-1/3 w-full mb-4 md:mb-0">
           <img
@@ -50,15 +52,16 @@
           </p>
 
           <!-- Register Button -->
-          <button
+          <a href="{{ event.registration_link }}">
+            <div class="relative inset-0"><button
               class="inline-block bg-[{{site.bg-colors.orange-button}}] text-white font-semibold px-4 py-2 rounded-lg mt-2 hover:bg-[{{site.bg-colors.orange-button}}]/80 transition-colors duration-300"
             >
               Register Now
-            </button>
+            </button></div>
+          </a>
         </div>
       </div>
     </div>
-  </a>
     {% endfor %}
   </div>
 </div>

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -8,8 +8,9 @@
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
     {% assign upcoming_events = site.events | where: 'completed', false | sort: 'date' | limit: 4 %}
     {% for event in upcoming_events %}
+    <a href="{{ event.url }}" class="block">
     <div
-      class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg"
+      class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
     >
       <div class="flex flex-col md:flex-row items-start md:items-center">
         <!-- Event Image -->
@@ -40,8 +41,8 @@
             >
 
             <!-- Read More / Read Less buttons -->
-            <a href="#" class="text-blue-400 read-more">Read More</a>
-            <a href="#" class="text-blue-400 read-less hidden">Show Less</a>
+            <button class="text-blue-400 read-more">Read More</button>
+            <button class="text-blue-400 read-less hidden">Show Less</button>
           </p>
 
           <p class="text-sm mb-1 text-gray-400 font-bold">
@@ -49,15 +50,15 @@
           </p>
 
           <!-- Register Button -->
-          <a
-            href="{{ event.url }}"
-            class="inline-block bg-[{{site.bg-colors.orange-button}}] text-white font-semibold px-4 py-2 rounded-lg mt-2 hover:bg-[{{site.bg-colors.orange-button}}]/80"
-          >
-            Register Now
-          </a>
+          <button
+              class="inline-block bg-[{{site.bg-colors.orange-button}}] text-white font-semibold px-4 py-2 rounded-lg mt-2 hover:bg-[{{site.bg-colors.orange-button}}]/80 transition-colors duration-300"
+            >
+              Register Now
+            </button>
         </div>
       </div>
     </div>
+  </a>
     {% endfor %}
   </div>
 </div>

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -31,21 +31,15 @@
             {{ event.date | date: "%a, %B %e, %Y" }}
           </p>
 
-          <!-- Event Description with Show More/Show Less -->
+          <!-- Event Description with Show More -->
           <p class="text-sm my-2">
             <!-- Shortened version of the description -->
             <span class="event-description-short"
               >{{ event.description | truncate: 120, "..." }}</span
             >
-            <!-- Full description, hidden initially -->
-            <span class="event-description-full hidden"
-              >{{ event.description }}</span
-            >
 
             <!-- Read More / Read Less buttons -->
             <button class="text-blue-400 read-more">Read More</button>
-            <button class="text-blue-400 read-less hidden">Show Less</button>
-          </p>
 
           <p class="text-sm mb-1 text-gray-400 font-bold">
             {{ event.participants }}


### PR DESCRIPTION
### Overview of Changes:
- Made the entire event card clickable for better navigation.
- Verified that the "Read More/Show Less" functionality inside the card operates as intended.
- Added a subtle scale-up animation effect to the card on hover.
- Converted the "Register Now" and "Read More/Show Less" links to buttons for improved accessibility.

This PR fixes issue #56.

Video Preview: https://github.com/user-attachments/assets/388159ba-baee-48b3-9213-a96ac9116693

