### PR TITLE
fix: upcoming event layout to center if 1 event else grid

### DIFF
--- a/_events/2024-12-01-hack-a-lite.markdown
+++ b/_events/2024-12-01-hack-a-lite.markdown
@@ -18,26 +18,32 @@ completed: true
 tags: ["hackathon", "innovation", "coding"]
 published: true
 ---
+
 <!-- Content -->
+
 ## Event Details
 
 Join us for **Hack-a-LITE 2024**, a thrilling 36-hour hackathon where innovators, developers, and tech enthusiasts come together to solve real-world problems and showcase their creativity. Whether you're a seasoned hacker or a beginner, this event will push your coding skills to the next level.
 
 ### Event Highlights
+
 - **Real-world Problem Solving**: Tackle real challenges and come up with innovative solutions.
 - **Collaboration & Networking**: Team up with like-minded individuals to build, learn, and compete.
 - **Exciting Prizes**: Stand a chance to win amazing rewards for the best projects!
 
 ### Event Schedule
+
 - **Start Time**: 9:00 AM, Sunday, November 17, 2024
 - **End Time**: 9:00 PM, Monday, November 18, 2024
 - **Venue**: Kantipur Engineering College
 
 ### How to Register
+
 To participate in Hack-a-LITE 2024, please register using the following link:  
 [**{{ button_text }}**]({{ registration_link }})
 
 ### Contact
+
 For any queries, feel free to reach out to us at [contact@computerclubkec.com](mailto:contact@computerclubkec.com).
 
 We look forward to your participation in this exciting hackathon!

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -5,59 +5,66 @@
     Upcoming Events
   </h2>
 
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
-    {% assign upcoming_events = site.events | where: 'completed', false | sort: 'date' | limit: 4 %}
-    {% for event in upcoming_events %}
-    <div
-      class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg"
-    >
-      <div class="flex flex-col md:flex-row items-start md:items-center">
-        <!-- Event Image -->
-        <div class="md:w-1/3 w-full mb-4 md:mb-0">
-          <img
-            src="{{ event.banner_image }}"
-            alt="{{ event.title }}"
-            class="w-full h-auto rounded-lg"
-          />
-        </div>
+  <!-- Fetch upcoming events -->
+  {% assign upcoming_events = site.events | where: 'completed', false | sort:
+  'date' | limit: 4 %} {% assign event_count = upcoming_events | size %}
 
-        <!-- Event Info -->
-        <div class="md:w-2/3 w-full md:pl-6">
-          <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
-          <p class="text-sm text-gray-400 italic font-semibold">
-            {{ event.date | date: "%a, %B %e, %Y" }}
-          </p>
+  <!-- Conditionally set grid based on the number of events -->
+  {% if event_count == 1 %}
+  <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
+    {% else %}
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
+      {% endif %} {% for event in upcoming_events %}
+      <div class="flex justify-center">
+        <div
+          class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-4 p-4 rounded-2xl shadow-lg {% if event_count == 1 %}w-[810px]{% endif %}"
+        >
+          <div class="flex flex-col md:flex-row items-start md:items-center">
+            <!-- Event Image -->
+            <div class="md:w-1/3 w-full mb-4 md:mb-0">
+              <img
+                src="{{ event.banner_image }}"
+                alt="{{ event.title }}"
+                class="w-60 h-60 object-cover rounded-lg"
+              />
+            </div>
 
-          <!-- Event Description with Show More/Show Less -->
-          <p class="text-sm my-2">
-            <!-- Shortened version of the description -->
-            <span class="event-description-short"
-              >{{ event.description | truncate: 120, "..." }}</span
-            >
-            <!-- Full description, hidden initially -->
-            <span class="event-description-full hidden"
-              >{{ event.description }}</span
-            >
+            <!-- Event Info -->
+            <div class="md:w-2/3 w-full md:pl-6">
+              <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
+              <p class="text-sm text-gray-400 italic font-semibold">
+                {{ event.date | date: "%a, %B %e, %Y" }}
+              </p>
 
-            <!-- Read More / Read Less buttons -->
-            <a href="#" class="text-blue-400 read-more">Read More</a>
-            <a href="#" class="text-blue-400 read-less hidden">Show Less</a>
-          </p>
+              <!-- Event Description with Show More/Show Less -->
+              <p class="text-sm my-2">
+                <span class="event-description-short">
+                  {{ event.description | truncate: 120, "..." }}
+                </span>
+                <span class="event-description-full hidden">
+                  {{ event.description }}
+                </span>
 
-          <p class="text-sm mb-1 text-gray-400 font-bold">
-            {{ event.participants }}
-          </p>
+                <a href="#" class="text-blue-400 read-more">Read More</a>
+                <a href="#" class="text-blue-400 read-less hidden">Show Less</a>
+              </p>
 
-          <!-- Register Button -->
-          <a
-            href="{{ event.url }}"
-            class="inline-block bg-[{{site.bg-colors.orange-button}}] text-white font-semibold px-4 py-2 rounded-lg mt-2 hover:bg-[{{site.bg-colors.orange-button}}]/80"
-          >
-            Register Now
-          </a>
+              <p class="text-sm mb-1 text-gray-400 font-bold">
+                {{ event.participants }}
+              </p>
+
+              <!-- Register Button -->
+              <a
+                href="{{ event.registration_link }}"
+                class="inline-block bg-[{{site.bg-colors.orange-button}}] text-white font-semibold px-4 py-2 rounded-lg mt-2 hover:bg-[{{site.bg-colors.orange-button}}]/80"
+              >
+                Register Now
+              </a>
+            </div>
+          </div>
         </div>
       </div>
+      {% endfor %}
     </div>
-    {% endfor %}
   </div>
 </div>

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -15,61 +15,61 @@
     {% else %}
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
       {% endif %} {% for event in upcoming_events %}
-      <div class="flex justify-center">
-        <div
-          class="relative bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer {% if event_count == 1 %}w-[810px]{% endif %}"
-        >
-          <a href="{{ event.url }}" class="absolute inset-0 block"></a>
-          <div class="flex flex-col md:flex-row items-start md:items-center">
-            <!-- Event Image -->
-            <div class="md:w-1/3 w-full mb-4 md:mb-0">
-              <img
-                src="{{ event.banner_image }}"
-                alt="{{ event.title }}"
-                class="md:w-60 w-full h-60 rounded-lg"
-              />
-            </div>
+      <div
+        class="relative bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer {% if event_count == 1 %}md:w-[810px] w-full{% endif %}"
+      >
+        <a href="{{ event.url }}" class="absolute inset-0 block"></a>
+        <div class="flex flex-col md:flex-row items-start md:items-center">
+          <!-- Event Image -->
+          <div class="md:w-1/3 w-full mb-4 md:mb-0">
+            <img
+              src="{{ event.banner_image }}"
+              alt="{{ event.title }}"
+              class="w-full h-auto md:h-60 md:w-60 rounded-lg"
+            />
+          </div>
 
-            <!-- Event Info -->
-            <div class="md:w-2/3 w-full md:pl-6">
-              <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
-              <p class="text-sm text-gray-400 italic font-semibold">
-                {{ event.date | date: "%a, %B %e, %Y" }}
-              </p>
+          <!-- Event Info -->
+          <div class="md:w-2/3 w-full md:pl-6">
+            <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
+            <p class="text-sm text-gray-400 italic font-semibold">
+              {{ event.date | date: "%a, %B %e, %Y" }}
+            </p>
 
-              <!-- Event Description with Show More/Show Less -->
-              <p class="text-sm my-2">
-                <span class="event-description-short"
-                  >{{ event.description | truncate: 120, "..." }}</span
+            <!-- Event Description with Show More/Show Less -->
+            <p class="text-sm my-2">
+              <!-- Shortened version of the description -->
+              <span class="event-description-short"
+                >{{ event.description | truncate: 120, "..." }}</span
+              >
+              <!-- Full description, hidden initially -->
+              <span class="event-description-full hidden"
+                >{{ event.description }}</span
+              >
+
+              <!-- Read More / Read Less buttons -->
+              <button class="text-blue-400 read-more relative z-10">
+                Read More
+              </button>
+              <button class="text-blue-400 read-less hidden relative z-10">
+                Show Less
+              </button>
+            </p>
+
+            <p class="text-sm mb-1 text-gray-400 font-bold">
+              {{ event.participants }}
+            </p>
+
+            <!-- Register Button -->
+            <a href="{{ event.registration_link }}">
+              <div class="relative inset-0">
+                <button
+                  class="inline-block bg-[{{site.bg-colors.orange-button}}] text-white font-semibold px-4 py-2 rounded-lg mt-2 hover:bg-[{{site.bg-colors.orange-button}}]/80 transition-colors duration-300"
                 >
-                <span class="event-description-full hidden"
-                  >{{ event.description }}</span
-                >
-
-                <!-- Read More / Read Less buttons -->
-                <button class="text-blue-400 read-more relative z-10">
-                  Read More
+                  Register Now
                 </button>
-                <button class="text-blue-400 read-less hidden relative z-10">
-                  Show Less
-                </button>
-              </p>
-
-              <p class="text-sm mb-1 text-gray-400 font-bold">
-                {{ event.participants }}
-              </p>
-
-              <!-- Register Button -->
-              <a href="{{ event.registration_link }}">
-                <div class="relative inset-0">
-                  <button
-                    class="inline-block bg-[{{site.bg-colors.orange-button}}] text-white font-semibold px-4 py-2 rounded-lg mt-2 hover:bg-[{{site.bg-colors.orange-button}}]/80 transition-colors duration-300"
-                  >
-                    Register Now
-                  </button>
-                </div>
-              </a>
-            </div>
+              </div>
+            </a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This pr resolves #50 

**PR Title:** Fix Events Layout for Single Upcoming Event

**Description:**
- Adjusted events listing layout for single upcoming event.
- Used conditional rendering based on the number of `completed: false` events.
- If only one event, it is centered and dix the height and width of the card.
- For multiple events, used a 2-column grid layout.
- Also fix the height and width of the image with responsive way.

**Previous:**

![image](https://github.com/user-attachments/assets/e00bf2e4-25e8-499d-ad45-d61877d10a94)

**Now:**

![Screenshot 2024-10-08 224844](https://github.com/user-attachments/assets/d102c41b-6a4b-4431-a757-0677c3a686ec)
