### PR TITLE
fix: update the layout for single event in recent events section

### DIFF
--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -5,63 +5,74 @@
     Recent Events
   </h2>
 
-  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
-    {% for event in site.events %} {% if event.completed %}
-    <a href="{{ event.url }}" class="block">
-    <div
-      class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
-    >
-      <div class="flex flex-col md:flex-row items-start md:items-center">
-        <!-- Event Image -->
-        <div class="md:w-1/3 w-full mb-4 md:mb-0">
-          <img
-            src="{{ event.banner_image }}"
-            alt="{{ event.title }}"
-            class="w-full h-auto rounded-lg"
-          />
-        </div>
+  <!-- Fetch upcoming events -->
+  {% assign recent_events = site.events | where: 'completed', true | sort:
+  'date' | limit: 4 %} {% assign event_count = recent_events | size %}
 
-        <!-- Event Info -->
-        <div class="md:w-2/3 w-full md:pl-6">
-          <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
-          <p class="text-sm text-gray-400 italic font-semibold">
-            {{ event.date | date: "%a, %B %e, %Y" }}
-          </p>
+  <!-- Conditionally set grid based on the number of events -->
+  {% if event_count == 1 %}
+  <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
+    {% else %}
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
+      {% endif %} {% for event in recent_events %}
+      <div
+        class="relative bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer {% if event_count == 1 %}md:w-[810px] w-full{% endif %}"
+      >
+        <a href="{{ event.url }}" class="absolute inset-0 block"></a>
+        <div class="flex flex-col md:flex-row items-start md:items-center">
+          <!-- Event Image -->
+          <div class="md:w-1/3 w-full mb-4 md:mb-0">
+            <img
+              src="{{ event.banner_image }}"
+              alt="{{ event.title }}"
+              class="w-full h-auto md:h-60 md:w-60 rounded-lg"
+            />
+          </div>
 
-          <!-- Event Description with Show More/Show Less -->
-          <p class="text-sm my-2">
-            <!-- Shortened version of the description -->
-            <span class="event-description-short"
-              >{{ event.description | truncate: 120, "..." }}</span
-            >
-            <!-- Full description, hidden initially -->
-            <span class="event-description-full hidden"
-              >{{ event.description }}</span
-            >
+          <!-- Event Info -->
+          <div class="md:w-2/3 w-full md:pl-6">
+            <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
+            <p class="text-sm text-gray-400 italic font-semibold">
+              {{ event.date | date: "%a, %B %e, %Y" }}
+            </p>
 
-            <!-- Read More / Read Less buttons -->
-            <button class="text-blue-400 read-more">Read More</button>
-            <button class="text-blue-400 read-less hidden">Show Less</button>
-          </p>
+            <!-- Event Description with Show More/Show Less -->
+            <p class="text-sm my-2">
+              <!-- Shortened version of the description -->
+              <span class="event-description-short"
+                >{{ event.description | truncate: 120, "..." }}</span
+              >
+              <!-- Full description, hidden initially -->
+              <span class="event-description-full hidden"
+                >{{ event.description }}</span
+              >
 
-          <p class="text-sm mb-1 text-gray-400 font-bold">
-            {{ event.participants }}
-          </p>
+              <!-- Read More / Read Less buttons -->
+              <button class="text-blue-400 read-more relative z-10">
+                Read More
+              </button>
+              <button class="text-blue-400 read-less hidden relative z-10">
+                Show Less
+              </button>
+            </p>
+
+            <p class="text-sm mb-1 text-gray-400 font-bold">
+              {{ event.participants }}
+            </p>
+          </div>
         </div>
       </div>
+      {% endfor %}
     </div>
-  </a>
-    {% endif %} {% endfor %}
   </div>
 
-
-  <div class="flex justify-center mt-8">
+  <!-- See More Button -->
+  <div class="flex justify-center">
     <a
       href="/past-events"
       class="text-[{{site.bg-colors.orange-button}}] hover:text-white border-2 border-[{{site.bg-colors.orange-button}}] hover:bg-[{{site.bg-colors.orange-button}}] focus:ring-4 focus:outline-none focus:ring-[{{site.bg-colors.orange-button}}]/50 font-medium rounded-lg text-xs sm:text-sm md:text-base lg:text-lg px-4 sm:px-6 py-2 sm:py-3 text-center mb-2 dark:border-[{{site.bg-colors.orange-button}}] dark:text-[{{site.bg-colors.orange-button}}] dark:hover:text-white dark:hover:bg-[{{site.bg-colors.orange-button}}] dark:focus:ring-[{{site.bg-colors.orange-button}}]/80"
     >
       See More
-  </a>
+    </a>
   </div>
-  
 </div>


### PR DESCRIPTION
This PR is follow up for #50 for `Recent Events Section`

## Changes

- Filters Completed Events and  sort them  according to the dates
- Checks for the condition if the no of events is 1
- Creates the grid according to the size

## Current Look
<img width="1565" alt="Screenshot 2024-10-09 at 11 18 13 PM" src="https://github.com/user-attachments/assets/89183242-690e-4ecb-ad40-41c1a1ce71c9">


## With this PR
<img width="917" alt="Screenshot 2024-10-09 at 11 13 38 PM" src="https://github.com/user-attachments/assets/a816190c-7b8b-4f82-b3bf-ae3fef8fcf69">
