### PR TITLE
feat: add the event end and start if the event spans multiple days

### DIFF
--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -8,52 +8,56 @@
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
     {% for event in site.events %} {% if event.completed %}
     <a href="{{ event.url }}" class="block">
-    <div
-      class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
-    >
-      <div class="flex flex-col md:flex-row items-start md:items-center">
-        <!-- Event Image -->
-        <div class="md:w-1/3 w-full mb-4 md:mb-0">
-          <img
-            src="{{ event.banner_image }}"
-            alt="{{ event.title }}"
-            class="w-full h-auto rounded-lg"
-          />
-        </div>
+      <div
+        class="bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
+      >
+        <div class="flex flex-col md:flex-row items-start md:items-center">
+          <!-- Event Image -->
+          <div class="md:w-1/3 w-full mb-4 md:mb-0">
+            <img
+              src="{{ event.banner_image }}"
+              alt="{{ event.title }}"
+              class="w-full h-auto rounded-lg"
+            />
+          </div>
 
-        <!-- Event Info -->
-        <div class="md:w-2/3 w-full md:pl-6">
-          <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
-          <p class="text-sm text-gray-400 italic font-semibold">
-            {{ event.date | date: "%a, %B %e, %Y" }}
-          </p>
+          <!-- Event Info -->
+          <div class="md:w-2/3 w-full md:pl-6">
+            <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
 
-          <!-- Event Description with Show More/Show Less -->
-          <p class="text-sm my-2">
-            <!-- Shortened version of the description -->
-            <span class="event-description-short"
-              >{{ event.description | truncate: 120, "..." }}</span
-            >
-            <!-- Full description, hidden initially -->
-            <span class="event-description-full hidden"
-              >{{ event.description }}</span
-            >
+            <!-- Event Date Logic -->
+            <p class="text-sm text-gray-400 italic font-semibold">
+              {% if event.end_date and event.date != event.end_date %} {{
+              event.date | date: "%a, %b %e, %Y" }} - {{ event.end_date | date:
+              "%a, %b %e, %Y" }} {% else %} {{ event.date | date: "%a, %b %e,
+              %Y" }} {% endif %}
+            </p>
 
-            <!-- Read More / Read Less buttons -->
-            <button class="text-blue-400 read-more">Read More</button>
-            <button class="text-blue-400 read-less hidden">Show Less</button>
-          </p>
+            <!-- Event Description with Show More/Show Less -->
+            <p class="text-sm my-2">
+              <!-- Shortened version of the description -->
+              <span class="event-description-short"
+                >{{ event.description | truncate: 120, "..." }}</span
+              >
+              <!-- Full description, hidden initially -->
+              <span class="event-description-full hidden"
+                >{{ event.description }}</span
+              >
 
-          <p class="text-sm mb-1 text-gray-400 font-bold">
-            {{ event.participants }}
-          </p>
+              <!-- Read More / Read Less buttons -->
+              <button class="text-blue-400 read-more">Read More</button>
+              <button class="text-blue-400 read-less hidden">Show Less</button>
+            </p>
+
+            <p class="text-sm mb-1 text-gray-400 font-bold">
+              {{ event.participants }}
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-  </a>
+    </a>
     {% endif %} {% endfor %}
   </div>
-
 
   <div class="flex justify-center mt-8">
     <a
@@ -61,7 +65,6 @@
       class="text-[{{site.bg-colors.orange-button}}] hover:text-white border-2 border-[{{site.bg-colors.orange-button}}] hover:bg-[{{site.bg-colors.orange-button}}] focus:ring-4 focus:outline-none focus:ring-[{{site.bg-colors.orange-button}}]/50 font-medium rounded-lg text-xs sm:text-sm md:text-base lg:text-lg px-4 sm:px-6 py-2 sm:py-3 text-center mb-2 dark:border-[{{site.bg-colors.orange-button}}] dark:text-[{{site.bg-colors.orange-button}}] dark:hover:text-white dark:hover:bg-[{{site.bg-colors.orange-button}}] dark:focus:ring-[{{site.bg-colors.orange-button}}]/80"
     >
       See More
-  </a>
+    </a>
   </div>
-  
 </div>

--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -27,10 +27,21 @@
 
             <!-- Event Date Logic -->
             <p class="text-sm text-gray-400 italic font-semibold">
-              {% if event.end_date and event.date != event.end_date %} {{
-              event.date | date: "%a, %b %e, %Y" }} - {{ event.end_date | date:
-              "%a, %b %e, %Y" }} {% else %} {{ event.date | date: "%a, %b %e,
-              %Y" }} {% endif %}
+              <!-- Display event dates -->
+              {% if event.end_date and event.end_date != "" %}
+              <!-- Convert dates to Unix Epoch for comparison -->
+              {% assign event_start_epoch = event.date | date: "%s" %} {% assign
+              event_end_epoch = event.end_date | date: "%s" %}
+
+              <!-- Check if the event spans multiple days -->
+              {% if event_start_epoch != event_end_epoch %}
+              <!-- Multi-day event: Show start and end dates -->
+              {{ event.date | date: "%a, %b %e, %Y" }} - {{ event.end_date |
+              date: "%a, %b %e, %Y" }} {% else %}
+              <!-- Single-day event: Show only the start date -->
+              {{ event.date | date: "%a, %b %e, %Y" }} {% endif %} {% else %}
+              <!-- No end date or it's a single-day event -->
+              {{ event.date | date: "%a, %b %e, %Y" }} {% endif %}
             </p>
 
             <!-- Event Description with Show More/Show Less -->

--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -36,19 +36,11 @@
             <!-- Event Date Logic -->
             <p class="text-sm text-gray-400 italic font-semibold">
               <!-- Display event dates -->
-              {% if event.end_date and event.end_date != "" %}
-              <!-- Convert dates to Unix Epoch for comparison -->
-              {% assign event_start_epoch = event.date | date: "%s" %} {% assign
-              event_end_epoch = event.end_date | date: "%s" %}
-
-              <!-- Check if the event spans multiple days -->
-              {% if event_start_epoch != event_end_epoch %}
+              {% if event.end_date %}
               <!-- Multi-day event: Show start and end dates -->
               {{ event.date | date: "%a, %b %e, %Y" }} - {{ event.end_date |
               date: "%a, %b %e, %Y" }} {% else %}
               <!-- Single-day event: Show only the start date -->
-              {{ event.date | date: "%a, %b %e, %Y" }} {% endif %} {% else %}
-              <!-- No end date or it's a single-day event -->
               {{ event.date | date: "%a, %b %e, %Y" }} {% endif %}
             </p>
 

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -33,13 +33,21 @@
           <div class="md:w-2/3 w-full md:pl-6">
             <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
             <p class="text-sm text-gray-400 italic font-semibold">
-              <!-- Event Date Logic -->
-              {% if event.end_date and event.date != event.end_date %}
-              <!-- Display start and end date if it's a multi-day event -->
-              {{ event.date | date: "%a, %B %e, %Y" }} - {{ event.end_date |
-              date: "%a, %B %e, %Y" }} {% else %}
-              <!-- Display only the start date if it's a single-day event -->
-              {{ event.date | date: "%a, %B %e, %Y" }} {% endif %}
+              <!-- Display event dates -->
+              {% if event.end_date and event.end_date != "" %}
+              <!-- Convert dates to Unix Epoch for comparison -->
+              {% assign event_start_epoch = event.date | date: "%s" %} {% assign
+              event_end_epoch = event.end_date | date: "%s" %}
+
+              <!-- Check if the event spans multiple days -->
+              {% if event_start_epoch != event_end_epoch %}
+              <!-- Multi-day event: Show start and end dates -->
+              {{ event.date | date: "%a, %b %e, %Y" }} - {{ event.end_date |
+              date: "%a, %b %e, %Y" }} {% else %}
+              <!-- Single-day event: Show only the start date -->
+              {{ event.date | date: "%a, %b %e, %Y" }} {% endif %} {% else %}
+              <!-- No end date or it's a single-day event -->
+              {{ event.date | date: "%a, %b %e, %Y" }} {% endif %}
             </p>
 
             <!-- Event Description with Show More/Show Less -->

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -34,19 +34,11 @@
             <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
             <p class="text-sm text-gray-400 italic font-semibold">
               <!-- Display event dates -->
-              {% if event.end_date and event.end_date != "" %}
-              <!-- Convert dates to Unix Epoch for comparison -->
-              {% assign event_start_epoch = event.date | date: "%s" %} {% assign
-              event_end_epoch = event.end_date | date: "%s" %}
-
-              <!-- Check if the event spans multiple days -->
-              {% if event_start_epoch != event_end_epoch %}
+              {% if event.end_date %}
               <!-- Multi-day event: Show start and end dates -->
               {{ event.date | date: "%a, %b %e, %Y" }} - {{ event.end_date |
               date: "%a, %b %e, %Y" }} {% else %}
               <!-- Single-day event: Show only the start date -->
-              {{ event.date | date: "%a, %b %e, %Y" }} {% endif %} {% else %}
-              <!-- No end date or it's a single-day event -->
               {{ event.date | date: "%a, %b %e, %Y" }} {% endif %}
             </p>
 

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -33,7 +33,13 @@
           <div class="md:w-2/3 w-full md:pl-6">
             <h3 class="md:text-2xl text-base font-bold">{{ event.title }}</h3>
             <p class="text-sm text-gray-400 italic font-semibold">
-              {{ event.date | date: "%a, %B %e, %Y" }}
+              <!-- Event Date Logic -->
+              {% if event.end_date and event.date != event.end_date %}
+              <!-- Display start and end date if it's a multi-day event -->
+              {{ event.date | date: "%a, %B %e, %Y" }} - {{ event.end_date |
+              date: "%a, %B %e, %Y" }} {% else %}
+              <!-- Display only the start date if it's a single-day event -->
+              {{ event.date | date: "%a, %B %e, %Y" }} {% endif %}
             </p>
 
             <!-- Event Description with Show More/Show Less -->


### PR DESCRIPTION
### Summary of the Changes

- adds the event end date in the home page if the event card if the event spans multiple days!
- This PR also resolves #58 

<img width="847" alt="Screenshot 2024-10-10 at 9 50 52 AM" src="https://github.com/user-attachments/assets/bf037858-a59e-4b67-995a-20187156162a">
