### PR TITLE
fix: reverse the sorting of the recent events

### DIFF
--- a/_events/kec-lite.markdown
+++ b/_events/kec-lite.markdown
@@ -16,7 +16,7 @@ participants: "1,200+ attendees."
 completed: true
 
 tags: ["Exhibit", "Compete", "Networking", "Annual"]
-published: true
+published: true 
 
 custom_layout: true
 ---

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -70,7 +70,7 @@
             <a href="#" class="block p-2 my-2">Past Events</a>
           </li>
           <li class="rounded-bl-xl rounded-br-xl hover:text-[#023047]">
-            <a href="/events/kec-lite-2024" class="block p-2 my-2">KEC Lite</a>
+            <a href="/events/kec-lite" class="block p-2 my-2">KEC Lite</a>
           </li>
         </ul>
       </li>

--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -7,7 +7,7 @@
 
   <!-- Fetch upcoming events -->
   {% assign recent_events = site.events | where: 'completed', true | sort:
-  'date' | limit: 4 %} {% assign event_count = recent_events | size %}
+  'date' | reverse | limit: 4 %} {% assign event_count = recent_events | size %}
 
   <!-- Conditionally set grid based on the number of events -->
   {% if event_count == 1 %}

--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -7,14 +7,14 @@
 
   <!-- Fetch upcoming events -->
   {% assign recent_events = site.events | where: 'completed', true | sort:
-  'date' | reverse | limit: 4 %} {% assign event_count = recent_events | size %}
+  'date' | reverse %} {% assign event_count = recent_events | size %}
 
   <!-- Conditionally set grid based on the number of events -->
   {% if event_count == 1 %}
   <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
     {% else %}
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
-      {% endif %} {% for event in recent_events %}
+      {% endif %} {% for event in recent_events limit: 4 %}
       <div
         class="relative bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer {% if event_count == 1 %}md:w-[810px] w-full{% endif %}"
       >

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -7,14 +7,14 @@
 
   <!-- Fetch upcoming events -->
   {% assign upcoming_events = site.events | where: 'completed', false | sort:
-  'date' | limit: 4 %} {% assign event_count = upcoming_events | size %}
+  'date' %} {% assign event_count = upcoming_events | size %}
 
   <!-- Conditionally set grid based on the number of events -->
   {% if event_count == 1 %}
   <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
     {% else %}
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
-      {% endif %} {% for event in upcoming_events %}
+      {% endif %} {% for event in upcoming_events limit: 4 %}
       <div
         class="relative bg-[{{site.bg-colors.darkBlue}}] text-white md:p-6 p-4 rounded-2xl shadow-lg transition-all duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer {% if event_count == 1 %}md:w-[810px] w-full{% endif %}"
       >


### PR DESCRIPTION
This PR fixes #87.

## Changes
- Add reverse sorting according to date for recent events
- The `limit` keyword works with the for loop, not with Assign so this PR fixes that to show most 4 recent and 4 upcoming events
- Rename `kec-lite-2024` to `kec-lite` so that each year same file can be modified as it's not relevant to glorify so much about KEC LITE in Computer Club's Site.