### PR TITLE
feat: add upcoming events page that displays all the upcoming events

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -62,7 +62,7 @@
           class="absolute pl-4 left-0 hidden m-0.5 w-[208px] bg-[{{ site.bg-colors.gray }}] border border-gray-300 z-10 rounded-bl-xl rounded-br-xl rounded-tr-xl text-base sm:text-sm md:text-base lg:text-lg"
         >
           <li class="rounded-tr-xl">
-            <a href="#" class="block p-2 my-2 hover:text-[#023047]"
+            <a href="/events/upcoming" class="block p-2 my-2 hover:text-[#023047]"
               >Upcoming Events</a
             >
           </li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,11 @@
   </head>
   <body>
     {% include nav.html %}
+      <h2
+        class="text-5xl font-bold text-[{{site.text-colors.darkblue}}] text-center py-10"
+      >
+        {{ page.title }}
+      </h2>
     <div class="content">{{ content }}</div>
     {% include footer.html %}
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>

--- a/upcoming-events.markdown
+++ b/upcoming-events.markdown
@@ -35,7 +35,7 @@ permalink: /events/upcoming
       </div>
 
       <!-- Event Info Below Image -->
-      <div class="text-center">
+      <div class="text-justify">
         <h3 class="text-xl font-semibold text-white">{{ event.title }}</h3>
         <p class="text-sm text-gray-300 italic font-semibold">
           {% if event.end_date %}

--- a/upcoming-events.markdown
+++ b/upcoming-events.markdown
@@ -1,0 +1,69 @@
+---
+layout: default
+title: Upcoming Events
+permalink: /events/upcoming
+
+---
+
+<div class="container pb-10 px-2 md:mx-auto">
+    
+   <!-- Fetch upcoming events -->
+  {% assign upcoming_events = site.events | where: 'completed', false | sort: 'date' %}
+  {% assign event_count = upcoming_events | size %}
+
+  <!-- Conditionally set grid based on the number of events -->
+  {% if event_count == 1 %}
+    <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
+  {% elsif event_count == 2 %}
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8">
+  {% else %}
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-8 items-start"> <!-- Added items-start -->
+  {% endif %}
+
+  {% for event in upcoming_events %}
+    <div
+      class="event-card relative bg-[{{site.bg-colors.darkBlue}}] p-6 rounded-2xl shadow-lg transition duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
+    >
+    <a href="{{ event.url }}" class="absolute inset-0 block"></a>
+      <!-- Event Image on Top -->
+      <div class="w-full flex justify-center">
+        <img
+          src="{{ event.banner_image }}"
+          alt="{{ event.title }}"
+          class="w-full h-auto rounded-md mb-4"
+        />
+      </div>
+
+      <!-- Event Info Below Image -->
+      <div class="text-center">
+        <h3 class="text-xl font-semibold text-white">{{ event.title }}</h3>
+        <p class="text-sm text-gray-300 italic font-semibold">
+          {% if event.end_date %}
+            {{ event.date | date: "%a, %b %e, %Y" }} - {{ event.end_date | date: "%a, %b %e, %Y" }}
+          {% else %}
+            {{ event.date | date: "%a, %b %e, %Y" }}
+          {% endif %}
+        </p>
+
+        <!-- Event Description with Show More/Show Less -->
+        <p class="text-sm my-2 text-white">
+          <span class="event-description-short">{{ event.description | truncate: 120, "..." }}</span>
+          <span class="event-description-full hidden">{{ event.description }}</span>
+
+          <button class="text-blue-400 read-more relative z-10">Read More</button>
+          <button class="text-blue-400 read-less hidden relative z-10">Show Less</button>
+        </p>
+
+        <!-- Register Button -->
+        <a href="{{ event.registration_link }}">
+          <button
+            class="inline-block bg-[{{site.bg-colors.orange-button}}] text-white font-semibold px-4 py-2 rounded-lg mt-2 hover:bg-[{{site.bg-colors.orange-button}}]/80 transition-colors duration-300"
+          >
+            Register Now
+          </button>
+        </a>
+      </div>
+    </div>
+  {% endfor %}
+  </div>
+</div>


### PR DESCRIPTION
This PR resolves #92 by displaying all the upcoming events in a single dedicated page.

## Output:

<img width="1567" alt="Screenshot 2024-10-14 at 4 35 49 PM" src="https://github.com/user-attachments/assets/fefb6ce2-cbed-42d3-ae36-9378cc972002">
