### PR TITLE
feat: add recent event pages

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -67,7 +67,7 @@
             >
           </li>
           <li class="hover:text-[#023047]">
-            <a href="#" class="block p-2 my-2">Past Events</a>
+            <a href="/events/past" class="block p-2 my-2">Past Events</a>
           </li>
           <li class="rounded-bl-xl rounded-br-xl hover:text-[#023047]">
             <a href="/events/kec-lite-2024" class="block p-2 my-2">KEC Lite</a>

--- a/past-events.markdown
+++ b/past-events.markdown
@@ -35,7 +35,7 @@ permalink: /events/past
       </div>
 
       <!-- Event Info Below Image -->
-      <div class="text-center">
+      <div class="text-justify">
         <h3 class="text-xl font-semibold text-white">{{ event.title }}</h3>
         <p class="text-sm text-gray-300 italic font-semibold">
           {% if event.end_date %}

--- a/past-events.markdown
+++ b/past-events.markdown
@@ -1,0 +1,60 @@
+---
+layout: default
+title: Past Events
+permalink: /events/past
+
+---
+
+<div class="container pb-10 px-2 md:mx-auto">
+
+   <!-- Fetch upcoming events -->
+  {% assign past_events = site.events | where: 'completed', true | sort: 'date' %}
+  {% assign event_count = past_events | size %}
+
+  <!-- Conditionally set grid based on the number of events -->
+  {% if event_count == 1 %}
+    <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
+  {% elsif event_count == 2 %}
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8">
+  {% else %}
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-8 items-start"> <!-- Added items-start -->
+  {% endif %}
+
+  {% for event in past_events %}
+    <div
+      class="event-card relative bg-[{{site.bg-colors.darkBlue}}] p-6 rounded-2xl shadow-lg transition duration-300 hover:shadow-xl hover:scale-[1.02] cursor-pointer"
+    >
+    <a href="{{ event.url }}" class="absolute inset-0 block"></a>
+      <!-- Event Image on Top -->
+      <div class="w-full flex justify-center">
+        <img
+          src="{{ event.banner_image }}"
+          alt="{{ event.title }}"
+          class="w-full h-auto rounded-md mb-4"
+        />
+      </div>
+
+      <!-- Event Info Below Image -->
+      <div class="text-center">
+        <h3 class="text-xl font-semibold text-white">{{ event.title }}</h3>
+        <p class="text-sm text-gray-300 italic font-semibold">
+          {% if event.end_date %}
+            {{ event.date | date: "%a, %b %e, %Y" }} - {{ event.end_date | date: "%a, %b %e, %Y" }}
+          {% else %}
+            {{ event.date | date: "%a, %b %e, %Y" }}
+          {% endif %}
+        </p>
+
+        <!-- Event Description with Show More/Show Less -->
+        <p class="text-sm my-2 text-white">
+          <span class="event-description-short">{{ event.description | truncate: 120, "..." }}</span>
+          <span class="event-description-full hidden">{{ event.description }}</span>
+
+          <button class="text-blue-400 read-more relative z-10">Read More</button>
+          <button class="text-blue-400 read-less hidden relative z-10">Show Less</button>
+        </p>
+      </div>
+    </div>
+  {% endfor %}
+  </div>
+</div>

--- a/past-events.markdown
+++ b/past-events.markdown
@@ -8,7 +8,7 @@ permalink: /events/past
 <div class="container pb-10 px-2 md:mx-auto">
 
    <!-- Fetch upcoming events -->
-  {% assign past_events = site.events | where: 'completed', true | sort: 'date' %}
+  {% assign past_events = site.events | where: 'completed', true | sort: 'date' | reverse %}
   {% assign event_count = past_events | size %}
 
   <!-- Conditionally set grid based on the number of events -->


### PR DESCRIPTION
This PR resolves #93. This will display all the past events without limit.

## Output:

<img width="1565" alt="Screenshot 2024-10-14 at 4 54 02 PM" src="https://github.com/user-attachments/assets/553710a3-5020-440b-90d2-cfbd292c70a2">

The title `Past Events` will be displayed by merging #97.