### PR TITLE
made recent events cards consistent

### DIFF
--- a/past-events.markdown
+++ b/past-events.markdown
@@ -26,17 +26,17 @@ permalink: /events/past
     >
     <a href="{{ event.url }}" class="absolute inset-0 block"></a>
       <!-- Event Image on Top -->
-      <div class="w-full flex justify-center">
-        <img
-          src="{{ event.banner_image }}"
-          alt="{{ event.title }}"
-          class="w-full h-auto rounded-md mb-4"
-        />
-      </div>
+    <div class="w-full flex justify-center items-center mb-4 aspect-square">
+      <img
+        src="{{ event.banner_image }}"
+        alt="{{ event.title }}"
+        class="h-full w-full object-contain rounded-md"
+      />
+    </div>
 
       <!-- Event Info Below Image -->
       <div class="text-justify">
-        <h3 class="text-xl font-semibold text-white">{{ event.title }}</h3>
+        <h3 class="text-xl font-semibold text-white truncate">{{ event.title }}</h3>
         <p class="text-sm text-gray-300 italic font-semibold">
           {% if event.end_date %}
             {{ event.date | date: "%a, %b %e, %Y" }} - {{ event.end_date | date: "%a, %b %e, %Y" }}


### PR DESCRIPTION
- Problem:
![issue](https://github.com/user-attachments/assets/2a2969ee-b62b-4a6f-9169-f63785cc666b)

- Now:
![image](https://github.com/user-attachments/assets/fbf9c85b-2642-4d01-b7e2-fbb83e8fc97a)

> As we have planned to use different image for thumbnail and that will be of standard size(1080*1080), the cards will look like this:
![image](https://github.com/user-attachments/assets/d60cf328-8f8b-4df2-b312-bdded35fd096)

> For images with different aspect ratio, they wont fill the card properly, but the cards will maintain their size.

Closes #100