### PR TITLE
fix: remove redundant about title

### DIFF
--- a/about.markdown
+++ b/about.markdown
@@ -1,13 +1,10 @@
 ---
 layout: default
-title: About
+title: About Us
 permalink: /about/
 ---
 
 <div class="container py-10 px-2 mx-auto items-center">
-  <h2 class="text-5xl font-bold text-[{{site.text-colors.darkblue}}] text-center mb-8">
-    About us
-  </h2>
 
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
     <div class="w-full h-full rounded-3xl overflow-hidden">


### PR DESCRIPTION
This PR fixes #106 

## Changes 
- Removed redundant title from About us Markdown 
- Changed `About` => `About Us`

## Current
![image](https://github.com/user-attachments/assets/893b5a4e-d75b-445b-bd58-1bd8fda89bb1)

## After Fix
![image](https://github.com/user-attachments/assets/9897b53d-d568-4e4a-a9c0-b5e6abf8b1ab)
