### PR TITLE
add lazy loading for images

### DIFF
--- a/_includes/brands_colab.html
+++ b/_includes/brands_colab.html
@@ -12,49 +12,49 @@
       class="flex flex-col lg:flex-row md:flex-row flex-wrap justify-center gap-10 items-center"
     >
       <div class="w-32 aspect-w-16 aspect-h-9">
-        <img
+        <img loading="lazy"
           class="object-contain h-auto"
           src="../assets/images/brands/leapfrog.png"
           alt="leapfrog"
         />
       </div>
       <div class="w-32 aspect-w-16 aspect-h-9">
-        <img
+        <img loading="lazy"
           class="object-contain h-auto"
           src="../assets/images/brands/khalti.png"
           alt="Khalti"
         />
       </div>
       <div class="w-32 aspect-w-16 aspect-h-9">
-        <img
+        <img loading="lazy"
           class="object-contain h-auto"
           src="../assets/images/brands/veda.png"
           alt="Veda Ingrails"
         />
       </div>
       <div class="w-32 aspect-w-16 aspect-h-9">
-        <img
+        <img loading="lazy"
           class="object-contain h-auto"
           src="../assets/images/brands/technoriyo.png"
           alt="Technoriyo"
         />
       </div>
       <div class="w-32 aspect-w-16 aspect-h-9">
-        <img
+        <img loading="lazy"
           class="object-contain h-auto"
           src="../assets/images/brands/digital_gurkha.png"
           alt="Digital Gurkha"
         />
       </div>
       <div class="w-32 aspect-w-16 aspect-h-9">
-        <img
+        <img loading="lazy"
           class="object-contain h-auto"
           src="../assets/images/brands/techaxis.png"
           alt="Techaxis"
         />
       </div>
       <div class="w-32 aspect-w-16 aspect-h-9">
-        <img
+        <img loading="lazy"
           class="object-contain h-auto"
           src="../assets/images/brands/bok.png"
           alt="Bank of Kathmandu"

--- a/_includes/executive-members.html
+++ b/_includes/executive-members.html
@@ -34,7 +34,7 @@
       class="member-card relative bg-[{{site.bg-colors.darkBlue}}] p-6 rounded-2xl transition duration-300 ease-in-out"
     >
       <div class="w-full flex justify-center">
-        <img
+        <img loading="lazy"
           src="{{ member.image }}"
           alt="{{ member.name }}"
           class="w-[300px] h-[300px] object-cover mb-4 2xl:mt-2 rounded-md"
@@ -79,7 +79,7 @@
       class="member-card relative bg-[{{site.bg-colors.darkBlue}}] p-6 rounded-2xl transition duration-300 ease-in-out"
     >
       <div class="w-full flex justify-center">
-        <img
+        <img loading="lazy"
           src="{{ member.image }}"
           alt="{{ member.name }}"
           class="w-[300px] h-[300px] object-cover 2xl:mt-2 mb-4 rounded-md"

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -5,7 +5,7 @@
 <div class="flex items-center">
   <div class="m-4 w-12 h-12 sm:w-8 sm:h-8 md:w-12 md:h-12 lg:w-16 lg:h-16 relative">
     <a href="{{ '/' }}">
-      <img
+      <img loading="lazy"
         src="{{ site.baseurl }}/assets/images/logo.png"
         alt="logo"
         class="absolute w-full h-full object-contain"

--- a/_includes/open-source-contributors.html
+++ b/_includes/open-source-contributors.html
@@ -16,7 +16,7 @@
       class="contributors-card relative bg-[{{site.bg-colors.darkBlue}}] p-6 rounded-2xl transition duration-300 ease-in-out"
     >
       <div class="w-full flex justify-center">
-        <img
+        <img loading="lazy"
           src="{{ contributors.image }}"
           alt="{{ contributors.name }}"
           class="w-[300px] h-[300px] object-cover mb-4 2xl:mt-2 rounded-md"

--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -22,7 +22,7 @@
         <div class="flex flex-col md:flex-row items-start md:items-center">
           <!-- Event Image -->
           <div class="md:w-1/3 w-full mb-4 md:mb-0">
-            <img
+            <img loading="lazy"
               src="{{ event.thumbnail }}"
               alt="{{ event.title }}"
               class="w-full h-auto md:h-60 md:w-60 rounded-lg"

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -22,7 +22,7 @@
         <div class="flex flex-col md:flex-row items-start md:items-center">
           <!-- Event Image -->
           <div class="md:w-1/3 w-full mb-4 md:mb-0">
-            <img
+            <img loading="lazy"
               src="{{ event.thumbnail }}"
               alt="{{ event.title }}"
               class="w-full h-auto md:h-60 md:w-60 rounded-lg"

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -63,7 +63,7 @@
           {% for post in sorted_posts %}
           <a href="{{ post.url }}" class="block blog-card-link">
             <div class="blog-card w-full m-2 p-4 border border-gray-300 rounded-lg shadow-lg bg-white cursor-pointer">
-              <img src="{{ post.image | default: '/assets/images/default-image.jpg' }}" 
+              <img loading="lazy" src="{{ post.image | default: '/assets/images/default-image.jpg' }}" 
                    alt="{{ post.title }}" 
                    class="w-full object-cover rounded-lg mb-4">
               <div class="blog-content">

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -43,7 +43,7 @@
       <div class="pb-10"></div>
       {% endif %}
 
-      <img
+      <img loading="lazy"
         src="{{ page.banner_image }}"
         alt="{{ page.title }}"
         class="max-w-[80vw] max-h-[50vh] w-auto h-auto mb-2 rounded-[20px] object-contain"

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -10,7 +10,7 @@
     <!-- Club Banner Starts Here -->
     <section id="club-banner">
       <div class="relative text-center">
-        <img
+        <img loading="lazy"
           src="/assets/images/banner.png"
           alt="KEC Computer Club Banner"
           class="w-full h-[45vh] sm:h-[50vh] object-cover"

--- a/about.markdown
+++ b/about.markdown
@@ -8,7 +8,7 @@ permalink: /about/
 
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">
     <div class="w-full h-full rounded-3xl overflow-hidden">
-      <img src="/assets/images/banner.png" alt="event-photo" class="w-full h-full object-cover">
+      <img loading="lazy" src="/assets/images/banner.png" alt="event-photo" class="w-full h-full object-cover">
     </div>
 
     <div class="flex flex-col items-start gap-4 w-full">

--- a/past-events.markdown
+++ b/past-events.markdown
@@ -27,7 +27,7 @@ permalink: /events/past-events
     <a href="{{ event.url }}" class="absolute inset-0 block"></a>
       <!-- Event Image on Top -->
     <div class="w-full flex justify-center items-center mb-4 aspect-square">
-      <img
+      <img loading="lazy"
         src="{{ event.banner_image }}"
         alt="{{ event.title }}"
         class="h-full w-full object-contain rounded-md"

--- a/upcoming-events.markdown
+++ b/upcoming-events.markdown
@@ -27,7 +27,7 @@ permalink: /events/upcoming
     <a href="{{ event.url }}" class="absolute inset-0 block"></a>
       <!-- Event Image on Top -->
       <div class="w-full flex justify-center">
-        <img
+        <img loading="lazy"
           src="{{ event.banner_image }}"
           alt="{{ event.title }}"
           class="w-full h-auto rounded-md mb-4"


### PR DESCRIPTION
Load the image only when it reaches user's viewport. 

> Lazy loading is a strategy to identify resources as non-blocking (non-critical) and load these only when needed. It's a way to shorten the length of the [critical rendering path](https://developer.mozilla.org/en-US/docs/Web/Performance/Critical_rendering_path), which translates into reduced page load times.

https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading

---
Point to be noted: Images size should be compressed. 
---
### Lighthouse Performance 

Before: 
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/6d31e61d-0ec4-4af2-9a41-f109edd0d325">


After: 
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/d651ee1a-adcc-4196-be9e-af221951ad28">
