### PR TITLE
fix: add text to indicate that there are no events

### DIFF
--- a/_includes/recent-events.html
+++ b/_includes/recent-events.html
@@ -9,8 +9,13 @@
   {% assign recent_events = site.events | where: 'completed', true | sort:
   'date' | reverse %} {% assign event_count = recent_events | size %}
 
+  {% if event_count == 0 %}
+  <div class="text-center text-gray-500 text-xl mt-16">
+    No recent events at the moment. Please check back later.
+  </div>
+
   <!-- Conditionally set grid based on the number of events -->
-  {% if event_count == 1 %}
+  {% elsif event_count == 1 %}
   <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
     {% else %}
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -9,8 +9,13 @@
   {% assign upcoming_events = site.events | where: 'completed', false | sort:
   'date' %} {% assign event_count = upcoming_events | size %}
 
+  {% if event_count == 0 %}
+<div class="text-center text-gray-500 text-xl mt-16">
+  No upcoming events at the moment. Please check back later.
+</div>
+
   <!-- Conditionally set grid based on the number of events -->
-  {% if event_count == 1 %}
+  {% elsif event_count == 1 %}
   <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
     {% else %}
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 md:gap-8">

--- a/past-events.markdown
+++ b/past-events.markdown
@@ -11,8 +11,13 @@ permalink: /events/past-events
   {% assign past_events = site.events | where: 'completed', true | sort: 'date' | reverse %}
   {% assign event_count = past_events | size %}
 
+  {% if event_count == 0 %}
+  <div class="text-center text-gray-500 text-xl mt-16">
+  No recent events at the moment. Please check back later.
+  </div>
+
   <!-- Conditionally set grid based on the number of events -->
-  {% if event_count == 1 %}
+  {% elsif event_count == 1 %}
     <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
   {% elsif event_count == 2 %}
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8">

--- a/upcoming-events.markdown
+++ b/upcoming-events.markdown
@@ -11,8 +11,13 @@ permalink: /events/upcoming
   {% assign upcoming_events = site.events | where: 'completed', false | sort: 'date' %}
   {% assign event_count = upcoming_events | size %}
 
+  {% if event_count == 0 %}
+  <div class="text-center text-gray-500 text-xl mt-16">
+  No upcoming events at the moment. Please check back later.
+</div>
+
   <!-- Conditionally set grid based on the number of events -->
-  {% if event_count == 1 %}
+  {% elsif event_count == 1 %}
     <div class="grid grid-cols-1 place-items-center gap-4 md:gap-8">
   {% elsif event_count == 2 %}
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-8">


### PR DESCRIPTION
This PR fixes #129.

## Current
<img width="1592" alt="Screenshot 2024-10-25 at 1 38 57 PM" src="https://github.com/user-attachments/assets/a85358db-ce30-4259-bbef-1251b7d25183">

## Changes

**At large screen**
<img width="1673" alt="Screenshot 2024-10-25 at 1 38 01 PM" src="https://github.com/user-attachments/assets/b4db0f41-e51a-4142-bd77-249a71a19348">

**At small screen**
![Screenshot 2024-10-25 at 1 38 04 PM](https://github.com/user-attachments/assets/b00e1684-80ef-4302-b280-296dd9121650)

**At Upcoming Events Page**
<img width="1612" alt="Screenshot 2024-10-25 at 1 41 00 PM" src="https://github.com/user-attachments/assets/98041af2-40a9-4f3c-9d30-e2c0b7b7b71c">

This also does for Recent Events despite the absence of the case of it being empty.
